### PR TITLE
fix: broken link

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -11,5 +11,5 @@ This website is meant to be my **\"home base\"** on the internet. I'll post some
 - 📽 Watch my videos on [YouTube](https://youtube.com/@ericmurphyxyz) or [Odysee](https://odysee.com/@ericnmurphy).
 - 📜 Find my dotfiles and scripts on [GitHub](https://github.com/ericmurphyxyz).
 - 💻 Want to know what programs I use on a daily basis? See my [Uses](/uses) page.
-- ✉ Want to get in touch? Feel free to [drop me a message](/contact).
+- ✉ Want to get in touch? Feel free to [drop me a message](mailto:eric@ericmurphy.xyz).
 {{</ card >}}


### PR DESCRIPTION
'drop me a message' text on home page links to a non-existent page thus 404. The fix links to your email similar to the menu item 'Contact'